### PR TITLE
可能？修复了一下手机端的https问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # API设置
 PORT=8812
-DEEPSEEK_API_KEY=your_deepseek_api_key
+DEEPSEEK_API_KEY=
 DEEPSEEK_API_URL=https://api.deepseek.com
 ALLOWED_ORIGINS=https://oooo.blog,https://chenpeel.github.io
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 version: "3"
-
 services:
   api:
     build: .
     container_name: deepseek-api
     restart: always
     ports:
-      - "443:8812"
+      - "8812:8812"
     environment:
       - PORT=8812
+      - NODE_ENV=production
+      - USE_HTTPS=false  
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
       - DEEPSEEK_API_URL=https://api.deepseek.com
       - ALLOWED_ORIGINS=https://oooo.blog,https://chenpeel.github.io
       - REDIS_URL=redis://redis:6379
     volumes:
       - ./logs:/app/logs
-      - /home/Gamma/.acme.sh/chenpeel.xyz_ecc:/etc/ssl/live/chenpeel.xyz:ro
     networks:
       - frontend
       - backend
@@ -30,13 +30,12 @@ services:
       - redis-data:/data
     command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
     networks:
-      - backend # 只连接到内部网络，无法直接从外部访问
+      - backend
 
-# 定义网络
 networks:
-  frontend: # 外部网络，用于与外界通信
-  backend: # 内部网络，用于内部服务间通信
-    internal: true # 将backend标记为内部网络，不能路由到外部
+  frontend:
+  backend:
+    internal: true
 
 volumes:
   redis-data:


### PR DESCRIPTION
需要重新删除容器并且创建

```
docker-compose down
docker-compose build --no-cache
docker-compose up -d
```

如果成功启动，访问本地的网站会显示OK
```
curl http://localhost:8812/health
```


开启外网访问需要给网站添加一个反向代理，如图所示

![image](https://github.com/user-attachments/assets/b30ca1b6-9a60-4cf2-ab72-68990efb6ac1)

关于ssl证书，我使用的是一键申请

![image](https://github.com/user-attachments/assets/3a5affea-c209-4294-8548-f6dbf337329f)
